### PR TITLE
feat(timer): add update rate counting for timers

### DIFF
--- a/include/metrics/detail/processor.hpp
+++ b/include/metrics/detail/processor.hpp
@@ -54,7 +54,7 @@ class processor_t {
         struct {
             std::map<
                 std::string,
-                timer<clock_type, histogram<accumulator::sliding::window_t>>
+                timer<clock_type, meter<clock_type>, histogram<accumulator::sliding::window_t>>
             > sw;
         } timers;
     } data;
@@ -113,17 +113,17 @@ public:
 
     /// \warning must be called from event loop's thread.
     template<class Accumulate>
-    const std::map<std::string, timer<clock_type, histogram<Accumulate>>>&
+    const std::map<std::string, timer<clock_type, meter<clock_type>, histogram<Accumulate>>>&
     timers() const;
 
     /// \overload
     /// \warning must be called from event loop's thread.
     template<class Accumulate>
-    std::map<std::string, timer<clock_type, histogram<Accumulate>>>&
+    std::map<std::string, timer<clock_type, meter<clock_type>, histogram<Accumulate>>>&
     timers() {
         typedef std::map<
             std::string,
-            metrics::detail::timer<clock_type, histogram<Accumulate>>
+            metrics::detail::timer<clock_type, metrics::detail::meter<clock_type>, histogram<Accumulate>>
         >& result_type;
 
         return const_cast<result_type>(static_cast<const processor_t&>(*this).timers<Accumulate>());
@@ -158,7 +158,7 @@ public:
 
     /// \warning must be called from event loop's thread.
     template<typename Accumulate>
-    timer<clock_type, histogram<Accumulate>>&
+    timer<clock_type, metrics::detail::meter<clock_type>, histogram<Accumulate>>&
     timer(const std::string& name) {
         return timers<Accumulate>()[name];
     }
@@ -187,7 +187,10 @@ processor_t::counters<std::uint64_t>() const {
 
 template<>
 inline
-const std::map<std::string, timer<processor_t::clock_type, histogram<accumulator::sliding::window_t>>>&
+const std::map<
+    std::string,
+    timer<processor_t::clock_type, meter<processor_t::clock_type>, histogram<accumulator::sliding::window_t>>
+>&
 processor_t::timers<accumulator::sliding::window_t>() const {
     return data.timers.sw;
 }

--- a/include/metrics/detail/timer.hpp
+++ b/include/metrics/detail/timer.hpp
@@ -10,13 +10,14 @@ namespace detail {
 /// throughput statistics via `meter`.
 ///
 /// \type `Clock` must meet `TrivialClock` requirements and must be steady.
-template<class Clock, class Histogram>
+template<class Clock, class Meter, class Histogram>
 class timer {
 public:
     typedef Clock clock_type;
     typedef typename clock_type::time_point time_point;
     typedef typename clock_type::duration duration_type;
 
+    typedef Meter meter_type;
     typedef Histogram histogram_type;
 
     // TODO: Suppress this check for GCC and pray, because `steady_clock` isn't available until 4.9.
@@ -27,6 +28,7 @@ public:
 private:
     struct data_t {
         clock_type clock;
+        meter_type meter;
         histogram_type histogram;
 
         template<typename... Args>
@@ -80,6 +82,11 @@ public:
         return d.histogram;
     }
 
+    const meter_type&
+    meter() const noexcept {
+        return d.meter;
+    }
+
     /// Lookup.
 
     std::uint64_t
@@ -93,7 +100,7 @@ public:
     void
     update(duration_type duration) {
         d.histogram.update(std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count());
-        // TODO: meter.mark();
+        d.meter.mark();
     }
 
     template<typename F>


### PR DESCRIPTION
Timers now can count update events rate. This is cheap.
