### PR TITLE
feat: instantiate ewma class with steady_clock

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+metrics (3.1.1-1) unstable; urgency=low
+
+  * fix: typo
+  * feat: instantiate ewma class with steady_clock
+
+ -- Kirill Smorodinnikov <shaitkir@gmail.com>  Mon, 21 May 2018 13:10:39 +0300
+
 metrics (3.1.0-1) unstable; urgency=low
 
   * Feature: allow to erase metrics from registry.

--- a/include/metrics/usts/ewma.hpp
+++ b/include/metrics/usts/ewma.hpp
@@ -69,6 +69,7 @@ public:
     auto get() const -> double;
 };
 
+// TODO: use steady_clock since it is expected that timer is monotonic.
 using ewma_t = ewma<std::chrono::high_resolution_clock>;
 
 } // namespace usts

--- a/src/usts/ewma.cpp
+++ b/src/usts/ewma.cpp
@@ -52,6 +52,7 @@ auto ewma<Clock>::warmed_up() const -> bool {
 }
 
 template class ewma<std::chrono::high_resolution_clock>;
+template class ewma<std::chrono::steady_clock>;
 
 }  // namespace usts
 }  // namespace metrics


### PR DESCRIPTION
`ewma` expects that time points are monotonically increased, so `steady_clock` should be used.